### PR TITLE
clean up remote after push

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,3 +12,4 @@ git config --global credential.'https://git-codecommit.*.amazonaws.com'.helper '
 git config --global credential.UseHttpPath true
 git remote add sync ${CodeCommitUrl}
 git push sync ${Branch} -f
+git remote remove sync


### PR DESCRIPTION
**What**
Remote the `sync` remote after push.

**Why**
To allow push to multiple regions (i.e. several iterations of the GH action in the same instance).